### PR TITLE
Fix for #13 Does not work since update from 2023.10.5 to 2023.11.0b0 

### DIFF
--- a/custom_components/google_assistant_sdk_custom/__init__.py
+++ b/custom_components/google_assistant_sdk_custom/__init__.py
@@ -8,7 +8,7 @@ import subprocess
 import homeassistant.components.google_assistant_sdk as google_assistant_sdk
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, DOMAIN as HA_DOMAIN
-from homeassistant.const import SERVICE_HOMEASSISTANT_RESTART
+from homeassistant.components.homeassistant.const import SERVICE_HOMEASSISTANT_RESTART
 
 _LOGGER = logging.getLogger(__name__)
 PATCH_FILE = os.path.dirname(os.path.realpath(__file__)) + "/google_assistant_sdk.patch"

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Google Assistant SDK Custom",
-  "homeassistant": "2023.9.0",
+  "homeassistant": "2023.11.0b0",
   "render_readme": true,
   "zip_release": true,
   "filename": "google_assistant_sdk_custom.zip"


### PR DESCRIPTION
After the merge https://github.com/tronikos/google_assistant_sdk_custom/issues/13 should be fixed. The path of SERVICE_HOMEASSISTANT_RESTART was adjusted and the version in which it was changed (2023.11.0b0) was set as Required.